### PR TITLE
Streamlined design + support for multiple areas. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,4 @@ Whooshka is making this standard openly available to encourage hackers and civic
 # What is a restriction "profile"
 In congested areas, street parking signages are often a nightmare because they have multiple "profiles".  A profile is basically a restriction that applies at that place, at that precise day, date, and time, and for individuals allowed to park there. A profile could also include prohibitions from parking, standing cars, loading-only zones, etc. The reason this gets very confusing is multiple profiles may crowd a single sign, making it all but incomprehensible.  By standardising the way we digitally store, parse and express this data, we can build tools and functionalities that help local governments manage and plan parking restrictions and also help digital applicatons display only contextually relevant signage data.  This is what Whooshka.me does.
 
-Take a look at whooshka.me and if our mission appeals to you, we'd love to hear from you!
-
-
-
-# Data Types
-All values are expressed as strings, unless they're booleans.  This is done to ensure that type casting is done at the time of implementation and to reduce complexity in the standard.
-
-Dates are therefore expressed according to [ISO 8601 standards](https://www.iso.org/iso-8601-date-and-time-format.html "ISO8601")
-
-
-
-
-
+Take a look at whooshka.me and if our mission appeals to you, we'd love to hear from you

--- a/parkingSigns_ standardisation_templatev6.json
+++ b/parkingSigns_ standardisation_templatev6.json
@@ -34,10 +34,10 @@
 			"description": "P",
 			"startTime": 480, // Minutes from 00:00 expressed as an integer.
 			"endTime": 960, // Minutes from 00:00 expressed as an integer.
-			"costPerHour": 4.80, // Expressed decimally in local currency.
+			"costPerHour": 4.80, // [OPTIONAL] Expressed decimally in local currency. If omitted or 0 then parking is not ticketed.
 			"currencyCode": "AUD", // International currency code standard ISO 4217.
-			"duration": 120, // [OPTIONAL] Minutes expressed decimally. If ommited then parking is unmetered.
-			"disabilityFactor": 1.0, // [OPTIONAL] Duration factor that disabled users can park in this space for. If ommited then 1 is assumed.
+			"duration": 120, // [OPTIONAL] Minutes expressed decimally. If omitted or 0 then parking is unmetered.
+			"disabilityFactor": 1.0, // [OPTIONAL] Duration factor that disabled users can park in this space for. If omitted then 1 is assumed.
 			"monday": true,
 			"tuesday": true,
 			"wednesday": true,
@@ -45,6 +45,7 @@
 			"friday": true,
 			"saturday": false,
 			"sunday": false,
+			"publicHoliday": false
 		}
   ]
 }

--- a/parkingSigns_ standardisation_templatev6.json
+++ b/parkingSigns_ standardisation_templatev6.json
@@ -1,49 +1,50 @@
 //(c) 2018 - 2028, Nitrous Development Pty Ltd (whooshka.me)
 // Licensed under CC-BY-SA v.4 (Creative Commons, Attribution, Share Alike)
 
-
-
 {
-  "collectionID": " ",  //collection id 
-  "typeDescription": "parking_restriction_data",
-  "UID": "alphanumericUID",
-  "councilID": "@melbourne",
-  "geometryType": "point/linestring",
-  "coordinates": "[lat, long]",
-  "numberOfProfiles": "[2, 3,4...]",
-  //one or more parking restriction "profiles" that apply to the street parking bay/ collection of bays  
-  "profile1": {
-    "profileDescription": "[parking/ disabled parking/ no stopping/ clearway / loading zone]",
-    "startTime": "[08:00]", //24H Format
-    "endTime": "[16:00]", // 24H Format
-    "costPerHour": "[480]in cents",
-    "maxDuration": "[60] in mins",
-    "disabilityFactor": "[1x, 2x...]",  //if people with disability permits can stay longer than the signed duration
-    "metered": true,
-    "monday": true,
-    "tuesday": true,
-    "wednesday": true,
-    "thursday": true,
-    "friday": true,
-    "saturday": false,
-    "sunday": false,
-    "applyOnPH": false
-  },
-  "profile2": {
-    "profileDescription": "[parking/ disabled parking/ no stopping/ clearway / loading zone]",
-    "startTime": "[08:00]",
-    "endTime": "[16:00]",
-    "costPerHour": "[480]",
-    "maxDuration": "[60]",
-    "disabilityFactor": "[1x, 2x...]",
-    "metered": false,
-    "monday": false,
-    "tuesday": false,
-    "wednesday": false,
-    "thursday": false,
-    "friday": false,
-    "saturday": true,
-    "sunday": true,
-    "applyOnPH": true
-  }
+	"collectionId": "",  // UUID v4 Identifier of parking restriction set.
+	"restrictionId": "", // UUID v4 Individual restriction identifier.
+	"governingBodyId": "", // UUID v4 Identifier of coulcil / local governing body.
+	// One or more areas that are governed by this set of profiles.
+	"areas": [
+		/*
+		point = A single parking bay defined by a single point.
+		line = A strip of parking bays along the path defined by two or more points (unclosed).
+		area = A collection of parking bays enclosed by multiple points that are closed. At least three points are required.
+		*/
+		"type": "point",
+		// Coordinates are pairs of latitude followed by longitude only, no vertical or CRS (ISO 6709).
+		// One point is two values, two points is four, three is six etc etc...
+		"coordinates": [
+			1.2345,
+			1.2345
+		],
+	],
+	// One or more parking restriction "profiles" that apply to the parking bay/collection of bays  
+	"profiles": [
+		{
+			/*
+			Description is one of the following codes
+			P = Parking
+			DP = Disabled Parking
+			NS = No Standing
+			CW = Clearway
+			LZ = Loading Zone
+			*/
+			"description": "P",
+			"startTime": 480, // Minutes from 00:00 expressed as an integer.
+			"endTime": 960, // Minutes from 00:00 expressed as an integer.
+			"costPerHour": 4.80, // Expressed decimally in local currency.
+			"currencyCode": "AUD", // International currency code standard ISO 4217.
+			"duration": 120, // [OPTIONAL] Minutes expressed decimally. If ommited then parking is unmetered.
+			"disabilityFactor": 1.0, // [OPTIONAL] Duration factor that disabled users can park in this space for. If ommited then 1 is assumed.
+			"monday": true,
+			"tuesday": true,
+			"wednesday": true,
+			"thursday": true,
+			"friday": true,
+			"saturday": false,
+			"sunday": false,
+		}
+  ]
 }


### PR DESCRIPTION
Converted a number of fields to numbers (startTime, endTime, costPerHour, duration and disability factor) of integer and double as that is the best way to represent such data and upon serialization this data would otherwise have to be converted manually anyway.

Changed "coordinates" into an object that strongly represents longitude and latitude GPS coordinates.

Added "areas" to allow one set of profiles to apply to multiple areas (e.g. two sides of the same street or multiple strips along one side of the street). Also now supports grouping an area of land such as off street parking (e.g. a pubic car parking area).

Removed "numberOfProfiles" for use of an array to represent the same data. The number is therefore reflected by the number of elements in the array.

Removed the "metered" boolean as this is implicitly represented by the "duration" (i.e. if the duration is 0 or omitted then parking is unmetered during the time of the profile.

Removed "applyOnPH" as there was no description as to what this field is for.

Removed "typeDescription" as there was no description as to what this field is for. The given value "parking_restriction_data" was implicit.